### PR TITLE
Allow base v4.16, bytestring v0.11

### DIFF
--- a/wuss.cabal
+++ b/wuss.cabal
@@ -26,8 +26,8 @@ source-repository head
 
 library
   build-depends:
-    base >= 4.13.0 && < 4.16
-    , bytestring >= 0.10.10 && < 0.11
+    base >= 4.13.0 && < 4.17
+    , bytestring >= 0.10.10 && < 0.12
     , connection >= 0.3.1 && < 0.4
     , network >= 3.1.1 && < 3.2
     , websockets >= 0.12.7 && < 0.13


### PR DESCRIPTION
Tested using `cabal build --constraint='bytestring==0.11.1.0'` with GHC 9.2.1 installed and the following `cabal.project`:

```
packages: .
source-repository-package
  location: git@github.com:tfausak/hs-memory.git
  tag: 3cf661a8a9a8ac028df77daa88e8d65c55a3347a
  type: git

source-repository-package
  location: git@github.com:TomMD/foundation.git
  tag: 0bb195e1fea06d144dafc5af9a0ff79af0a5f4a0
  type: git
  subdir: basement

source-repository-package
  location: git@github.com:josephcsible/cryptonite.git
  tag: 3b081e3ad027b0550fc87f171dffecbb20dedafe
  type: git
```
