### PR TITLE
Use crypton-connection instead of connection

### DIFF
--- a/wuss.cabal
+++ b/wuss.cabal
@@ -33,7 +33,7 @@ common library
   build-depends:
     , base >= 4.16.0 && < 4.19
     , bytestring >= 0.11.3 && < 0.12
-    , connection >= 0.3.1 && < 0.4
+    , crypton-connection >= 0.3.1 && < 0.4
     , exceptions >= 0.10.4 && < 0.11
     , network >= 3.1.2 && < 3.2
     , websockets >= 0.12.7 && < 0.13


### PR DESCRIPTION
Follows the change introduced in tls 1.7.0. Fixes building.