### PR TITLE
Relax the version bounds for data-default

### DIFF
--- a/wuss.cabal
+++ b/wuss.cabal
@@ -34,7 +34,7 @@ common library
   build-depends:
     bytestring ^>=0.11.4.0 || ^>=0.12.0.2,
     crypton-connection ^>=0.3.2 || ^>=0.4.0,
-    data-default >= 0.7 && <0.9,
+    data-default ^>=0.7.0 || ^>=0.8.0.0,
     exceptions ^>=0.10.7,
     network ^>=3.1.4.0 || ^>=3.2.0.0,
     websockets ^>=0.12.7.3 || ^>=0.13.0.0,

--- a/wuss.cabal
+++ b/wuss.cabal
@@ -34,7 +34,7 @@ common library
   build-depends:
     bytestring ^>=0.11.4.0 || ^>=0.12.0.2,
     crypton-connection ^>=0.3.2 || ^>=0.4.0,
-    data-default ^>=0.8.0.0,
+    data-default >= 0.7 && <0.9,
     exceptions ^>=0.10.7,
     network ^>=3.1.4.0 || ^>=3.2.0.0,
     websockets ^>=0.12.7.3 || ^>=0.13.0.0,


### PR DESCRIPTION
Unless I'm missing something, wuss doesn't seem to depend on [the updates on data-default-0.8.0.0](https://github.com/mauke/data-default/blob/master/Changes.pod#version-history-for-data-default)